### PR TITLE
Update S10_create_ext_scaffolding.sh

### DIFF
--- a/manual_build/S10_create_ext_scaffolding.sh
+++ b/manual_build/S10_create_ext_scaffolding.sh
@@ -29,15 +29,38 @@ then
       fi
     done
 
-    # Quake launchers
-    echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE/id1/Quake.fbl"
-    echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE/hipnotic/Mission pack 1.fbl"
-    echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE/rogue/Mission pack 2.fbl"
-    echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE/dopa/Episode 5. Dimension of the Past.fbl"
 
-    # Quake2 launchers
-    echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE2/baseq2/Quake II.fbl"
-    echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE2/rogue/Ground Zero.fbl"
-    echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE2/xatrix/The Reckoning.fbl"
-    echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE2/zaero/Zaero.fbl"
+    for dir in roms/QUAKE/id1 roms/QUAKE/hipnotic roms/QUAKE/rogue	\
+		roms/QUAKE/dopa roms/QUAKE2/baseq2 roms/QUAKE2/rogue		\
+		roms/QUAKE2/xatrix roms/QUAKE2/zaero
+    do
+      if [ -e "/media/sdcard/${dir}/pak0.pak" ]; then
+		# Quake launchers
+		if [ ${dir} = roms/QUAKE/id1 ]; then
+			echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE/id1/Quake.fbl"
+		fi
+		if [ ${dir} = roms/QUAKE/hipnotic ]; then
+			echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE/hipnotic/Mission pack 1.fbl"
+		fi
+		if [ ${dir} = roms/QUAKE/rogue ]; then
+			echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE/rogue/Mission pack 2.fbl"
+		fi
+		if [ ${dir} = roms/QUAKE/dopa ]; then
+			echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE/dopa/Episode 5. Dimension of the Past.fbl"
+		fi
+		# Quake 2 launchers
+		if [ ${dir} = roms/QUAKE2/baseq2 ]; then
+			echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE2/baseq2/Quake II.fbl"
+		fi
+		if [ ${dir} = roms/QUAKE2/rogue ]; then
+			echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE2/rogue/Ground Zero.fbl"
+		fi
+		if [ ${dir} = roms/QUAKE2/xatrix ]; then
+			echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE2/xatrix/The Reckoning.fbl"
+		fi
+		if [ ${dir} = roms/QUAKE2/zaero ]; then
+			echo "exec=pak0.pak" > "/media/sdcard/roms/QUAKE2/zaero/Zaero.fbl"
+		fi
+      fi
+    done
 fi


### PR DESCRIPTION
Only create the .fbl shortcuts (and therefore show the Quake menus) if the .pak files are present