### PR TITLE
update Py Backup config.ini for FBA configs

### DIFF
--- a/manual_build/config.ini
+++ b/manual_build/config.ini
@@ -1,7 +1,7 @@
 [DEFAULT]
 destination_directory = /media/sdcard/backups
 systems = 
-	FBA,True,/media/data/local/home/.fba/saves
+	FBA,True,/media/data/local/home/.fba/saves,/media/data/local/home/.fba/configs
 	ReGBA (GBA),True,/media/data/local/home/.gpsp
 	PCSX4All (PS),True,/media/data/local/home/.pcsx4all/sstates,/media/data/local/home/.pcsx4all/memcards
 	xMAME (ARCADE),True,/media/data/local/share/xmame/xmame52/sta,/media/data/local/share/xmame/xmame69/sta,/media/data/local/share/xmame/xmame84/sta


### PR DESCRIPTION
Include FBA configs folder in backup to allow individual game settings to be restored, such as screen orientation